### PR TITLE
`register()`: Extend types.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ const defaultPreLoadable: EnhancedPreLoadable = {
 
 let i = 0;
 
-const register = (component: PreLoadable) => {
+const register = (component: PreLoadable & Partial<EnhancedPreLoadable>) => {
     const enhancedComponent: Component = {
         name: `Component${i++}`,
         ...defaultPreLoadable,


### PR DESCRIPTION
The `register` function is currently typed to receive only `PreLoadable` params. Allowing it to receive partial values of `EnhancedPreLoadable` will fix typing errors when using parameters such as `cached`, `placeholder` and `extract`.

As an example, I was having a really hard time understanding why the following code wasn't working: 
`register({ require: () => require('./TestComponent').NamedExport })`. 

The reason this wasn't possible is because `getComponent` (in `map.ts`) takes the `extract` variable and uses it to extract a named (or default) export from the given `require` function. This was never clear to me because the `register` function doesn't accept in any of the `cached`, `placeholder` or `extract` values form the `EnhancedPreLoadable` type.

I was then able to fix my issue by simply changing my function signature to:
`register({ extract: 'NamedExport', require: () => require('./TestComponent') })`. 

This works perfectly, but still leaves TS errors as `register` is not typed to receive `EnhancedPreLoadable` variables.