### PR TITLE
[RNBS-024] - strictly typed `optimized` component

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ const defaultPreLoadable: EnhancedPreLoadable = {
 
 let i = 0;
 
-const register = <P extends any>(component: PreLoadable & Partial<EnhancedPreLoadable>) => {
+const register = <P extends {}>(component: PreLoadable & Partial<EnhancedPreLoadable>) => {
     const enhancedComponent: Component = {
         name: `Component${i++}`,
         ...defaultPreLoadable,
@@ -27,7 +27,7 @@ const register = <P extends any>(component: PreLoadable & Partial<EnhancedPreLoa
 
     mapLoadable[name] = enhancedComponent;
 
-    return optimized(name) as ComponentClass<P>;
+    return optimized<P>(name);
 };
 
 const component = (name: string) => getComponent(name);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+import { ComponentClass } from 'react';
+
 import optimized from './optimized';
 import { mapLoadable } from './bundler';
 import { Component, EnhancedPreLoadable, PreLoadable } from './interface';
@@ -11,7 +13,7 @@ const defaultPreLoadable: EnhancedPreLoadable = {
 
 let i = 0;
 
-const register = (component: PreLoadable & Partial<EnhancedPreLoadable>) => {
+const register = <P extends any>(component: PreLoadable & Partial<EnhancedPreLoadable>) => {
     const enhancedComponent: Component = {
         name: `Component${i++}`,
         ...defaultPreLoadable,
@@ -25,7 +27,7 @@ const register = (component: PreLoadable & Partial<EnhancedPreLoadable>) => {
 
     mapLoadable[name] = enhancedComponent;
 
-    return optimized(name);
+    return optimized(name) as ComponentClass<P>;
 };
 
 const component = (name: string) => getComponent(name);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+import * as React from 'react';
+
 import optimized from './optimized';
 import { mapLoadable } from './bundler';
 import { Component, EnhancedPreLoadable, PreLoadable } from './interface';
@@ -25,7 +27,7 @@ const register = <P extends {}>(component: PreLoadable & Partial<EnhancedPreLoad
 
     mapLoadable[name] = enhancedComponent;
 
-    return optimized<P>(name);
+    return optimized(name) as React.ComponentClass<P>;
 };
 
 const component = (name: string) => getComponent(name);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,3 @@
-import { ComponentClass } from 'react';
-
 import optimized from './optimized';
 import { mapLoadable } from './bundler';
 import { Component, EnhancedPreLoadable, PreLoadable } from './interface';

--- a/src/optimized.tsx
+++ b/src/optimized.tsx
@@ -11,7 +11,7 @@ type State = {
   isComponentAvailable: boolean;
 };
 
-const optimized = <T extends {}>(screenName: string): any => {
+const optimized = <T extends {}>(screenName: string) => {
   class OptimizedComponent<T> extends React.PureComponent<Props<T>, State> {
     private component: React.ElementType | null = null;
     private placeholder: React.ElementType | null = mapLoadable[screenName].placeholder;

--- a/src/optimized.tsx
+++ b/src/optimized.tsx
@@ -11,7 +11,7 @@ type State = {
   isComponentAvailable: boolean;
 };
 
-const optimized = <T extends {}>(screenName: string) => {
+const optimized = <T extends {}>(screenName: string): any => {
   class OptimizedComponent<T> extends React.PureComponent<Props<T>, State> {
     private component: React.ElementType | null = null;
     private placeholder: React.ElementType | null = mapLoadable[screenName].placeholder;


### PR DESCRIPTION
## Description

Make `optimized` HOC more strictly type. Before it returned `any` type, which could lead to some cases, where TS checks are broken.

## Motivation And Context

The case why it's needed well described in https://github.com/kirillzyusko/react-native-bundle-splitter/issues/33

As a solution for this problem I decided to use `as` operator. It's not very convenient, since we force TS to use our own types. But I didn't find a quick and reliable way to fix it properly.

`React.forwardRef` returns `ForwardRefExoticComponent`. If we remove `any` as a returned type from `optimized`, then `<A />` (see code below) will complain about missing `forwardedRef`. It's incorrect, since `forwardedRef` is used only internally. I've been trying to use different `Props` on different component levels. Though anyway I was needed to use `as` operator and write more code.

Taking into consideration everything that I said before, I thought it will be easier/faster to use the way, which I use in this MR.

I decided to cast `optimized` to `React.ComponentClass`, since `optimized` is class-based component, so it should be correct.

## How it has been tested?

Code below should throw expected `Property 'a' is missing in type '{}' but required in type 'Readonly<{ a: number; }>'.ts(2741)` error.

```ts
import React from "react";
import { register } from "./index";

const A = register<{ a: number }>({
  loader: () => import("./utils"),
});

<A />
```