### PR TITLE
chore: reduced npm package size

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -5,6 +5,7 @@
 
 # user
 .gitignore
+.github
 tsconfig.json
 docs
 gifs

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-bundle-splitter",
   "author": "Kiryl Ziusko",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "description": "Decrease your start up time and RAM memory consumption by an application via splitting JS bundle by components and navigation routes",
   "repository": "https://github.com/kirillzyusko/react-native-bundle-splitter",
   "homepage": "https://kirillzyusko.github.io/react-native-bundle-splitter/",


### PR DESCRIPTION
Just discovered, that the content of `.github` folder is also getting published to `npm`. It's not desirable behavior so in this PR i'm excluding `.github` folder from being published.