### PR TITLE
TypeError: Cannot read property "require" of undefined

### DIFF
--- a/src/map.ts
+++ b/src/map.ts
@@ -27,7 +27,7 @@ const nonBlockingLoader = (loader: RequireLoader | ImportLoader) => new Promise(
 });
 
 export const getComponent = async (name: string) => {
-    if (!isCached(name)) {
+    if (!isCached(name) && mapLoadable[name]) {
         const { require: load, loader, ...rest } = mapLoadable[name];
         let component = null;
 


### PR DESCRIPTION
Hi I found an issue that spam our sentry and development screens. 
After few testing on this liblary I found that  `mapLoadable[name]` can be undefined. So when you extract with `const {require, loader, ...} = mapLoadable[name]` it will trow an error.

 https://github.com/kirillzyusko/react-native-bundle-splitter/blob/c44c7bd3ba24d76d23a0afcb52ff366a2593c545/src/map.ts#L31
 
 I'm trying to fix this by adding condition on top of that code, by cheking `mapLoadable[name]` exist, before extract the value.