### PR TITLE
docs: changed URL for GitHub link

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -89,7 +89,7 @@ const config = {
             dropdownActiveClassDisabled: true,
           },
           {
-            href: 'https://github.com/facebook/docusaurus',
+            href: 'https://github.com/kirillzyusko/react-native-bundle-splitter',
             label: 'GitHub',
             position: 'right',
           },


### PR DESCRIPTION
Redirect to the GitHub page of this project (not docusaurus).