### PR TITLE
Fix: investigator function result

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -12,11 +12,14 @@ export const investigate = () => {
     const modules = require.getModules();
     const loaded = [];
     const waiting = [];
-    for (const [key, module] of modules) {
-        if (module.isInitialized) {
-            loaded.push(module.verboseName);
-        } else {
-            waiting.push(module.verboseName);
+    if (modules instanceof Map) {
+        for (const [key, module] of modules) {
+            (module.isInitialized ? loaded : waiting).push(module.verboseName);
+        }
+    } else {
+        for (const key of Object.keys(modules)) {
+            const module = modules[key];
+            (module.isInitialized ? loaded : waiting).push(module.verboseName);
         }
     }
 


### PR DESCRIPTION
Fix https://github.com/kirillzyusko/react-native-bundle-splitter/issues/74

Due to https://github.com/facebook/metro/pull/1301, require.getModules() now returns a Map rather than object